### PR TITLE
Add custom date-format to exercise template

### DIFF
--- a/src/exercise.typ
+++ b/src/exercise.typ
@@ -67,6 +67,8 @@
     author: none,
     date: datetime.today(),
 
+    date-format: (date) => date.display("[day].[month].[year]"),
+
     // if set, above attributes featuring automatic generation of the header are ignored
     header: none,
     header-right: none,
@@ -194,7 +196,7 @@
                 #show: align.with(top + right)
                 #ifnn-line(document-title)
                 #ifnn-line(author)
-                #ifnn-line(date.display("[day].[month].[year]"))
+                #ifnn-line(date-format(date))
                 #context {
                     if state("grape-suite-timefield").at(here()) != 1 {
                         if show-timefield {


### PR DESCRIPTION
Not all of the templates provided have a way to set a custom date format. This commit adds that feature to the exercise format.