### PR TITLE
fix[seminar-paper] dont include declaration of independent work in pagecount

### DIFF
--- a/src/seminar-paper.typ
+++ b/src/seminar-paper.typ
@@ -211,6 +211,7 @@
     if show-declaration-of-independent-work {
         pagebreak(weak: true)
         set page(footer: [])
+        counter(page).update(coutnter(page) - 1)
 
         heading(outlined: false, numbering: none, [Selbstständigkeitserklärung])
         [Hiermit versichere ich, dass ich die vorliegende schriftliche Hausarbeit (Seminararbeit, Belegarbeit) selbstständig verfasst und keine anderen als die von mir angegebenen Quellen und Hilfsmittel benutzt habe. Die Stellen der Arbeit, die anderen Werken wörtlich oder sinngemäß entnommen sind, wurden in jedem Fall unter Angabe der Quellen (einschließlich des World Wide Web und anderer elektronischer Text- und Datensammlungen) kenntlich gemacht. Dies gilt auch für beigegebene Zeichnungen, bildliche Darstellungen, Skizzen und dergleichen. Ich versichere weiter, dass die Arbeit in gleicher oder ähnlicher Fassung noch nicht Bestandteil einer Prüfungsleistung oder einer schriftlichen Hausarbeit (Seminararbeit, Belegarbeit) war. Mir ist bewusst, dass jedes Zuwiderhandeln als Täuschungsversuch zu gelten hat, aufgrund dessen das Seminar oder die Übung als nicht bestanden bewertet und die Anerkennung der Hausarbeit als Leistungsnachweis/Modulprüfung (Scheinvergabe) ausgeschlossen wird. Ich bin mir weiter darüber im Klaren, dass das zuständige Lehrerprüfungsamt/Studienbüro über den Betrugsversuch informiert werden kann und Plagiate rechtlich als Straftatbestand gewertet werden.]


### PR DESCRIPTION
When activated, the page 'declaration of independent work' was included into the page count. This should not be the case, because it is not a part of the actual paper.