### PR TITLE
WIP: Feature: make-element block-options

### DIFF
--- a/src/tasks.typ
+++ b/src/tasks.typ
@@ -5,7 +5,7 @@
 #let nobreak(body) = block(breakable: false, body)
 #let center-block(body) = align(center, block(align(left, body)))
 
-#let make-element(no, title, instruction, body, points, lines, element-type, body-options: none) = {
+#let make-element(no, title, instruction, body, points, lines, element-type, title-block-options: none, body-options: none) = {
     let title = (
         if title != none [ --- #title] + h(1fr) + if points > 0 [#points P.]
     )
@@ -14,6 +14,7 @@
         inset: 7pt,
         stroke: (bottom: (paint: c.primary, dash: "dashed")),
         fill: c.accent-light,
+        ..title-block-options,
         {
             text(fill: c.primary, strong[#element-type #no] + title)
         },

--- a/src/tasks.typ
+++ b/src/tasks.typ
@@ -5,7 +5,7 @@
 #let nobreak(body) = block(breakable: false, body)
 #let center-block(body) = align(center, block(align(left, body)))
 
-#let make-element(no, title, instruction, body, points, lines, element-type) = {
+#let make-element(no, title, instruction, body, points, lines, element-type, body-options: none) = {
     let title = (
         if title != none [ --- #title] + h(1fr) + if points > 0 [#points P.]
     )
@@ -19,7 +19,7 @@
         },
     )
 
-    block(width: 100%, {
+    block(width: 100%, ..body-options, {
         state("grape-suite-subtask-indent").update((0,))
 
         if instruction != none and instruction not in ([], [ ]) {
@@ -424,6 +424,9 @@
 
     // optional: body (and optional legacy arguments: solution, hint)
     ..body,
+
+    // optional: args for the body-box
+    body-options: none
 ) = (
     counter(if extra { "tasks" } else { "extra-tasks" }).step()
         + context {
@@ -501,6 +504,7 @@
                     t.body,
                     t.points,
                     lines,
+                    body-options: body-options,
                     if type != none { type } else if t.extra {
                         extra-task-type
                     } else { task-type },


### PR DESCRIPTION
I added two new arguements, so that one can customize the blocks from "make-element" better.
For example I add "sticky: true" to the title-block.

I choose deaults, such that the existing projects still compile the same.