### PR TITLE
Fix wrong numbering

### DIFF
--- a/src/tasks.typ
+++ b/src/tasks.typ
@@ -425,7 +425,7 @@
     // optional: body (and optional legacy arguments: solution, hint)
     ..body,
 ) = (
-    counter(if extra { "tasks" } else { "extra-tasks" }).step()
+    counter(if extra { "extra-tasks" } else { "tasks" }).step()
         + context {
             let task-translation-state = state(
                 "grape-suite-task-translations",
@@ -452,7 +452,7 @@
             }
 
             let no = numbering-format(
-                ..counter(if extra { "tasks" } else { "extra-tasks" }).at(
+                ..counter(if extra { "extra-tasks" } else { "tasks" }).at(
                     here(),
                 ),
             )


### PR DESCRIPTION
As mentioned by @NiklasVousten in #28. I fixed the counters and tested it:

```typst
#import ... as grape-suite
#import grape-suite: *
#import tasks: *

#show: exercise.project

Task #context counter("tasks").at(here())
Extra #context counter("extra-tasks").at(here())
#task(
  [Wrong Counter],
  none,
  [
    This is a fancy task
  ]
)
Task #context counter("tasks").at(here())
Extra #context counter("extra-tasks").at(here())
#task(
  [Wrong Counter Extra],
  none,
  extra: true,
  [
    This is a fancy task
  ]
)
Task #context counter("tasks").at(here())
Extra #context counter("extra-tasks").at(here())
```